### PR TITLE
Allows to run debug on any current open file given it is compiled

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
             "name": "OCaml",
             "type": "ocamldebug",
             "request": "launch",
-            "program": "${workspaceRoot}/inlecture.d.byte",
+            "program": "${fileDirname}/${fileBasenameNoExtension}.d.byte",
             "stopOnEntry": false,
             "preLaunchTask": "build" // Build before launch        
         }


### PR DESCRIPTION
Lets vs code look in cur directory for a {fileName}.d.byte
The file must be opened/selected in the editor and compiled.
Still works with the default make.